### PR TITLE
chore: replace stale MCP tool references and update skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,6 +21,10 @@ Use MCP tools for **all** operations. Never use `Read`, `Write`, `Edit`, or `Bas
 | Read reference project | `mcp__workspace__read_reference_file` |
 | List reference dir | `mcp__workspace__list_reference_directory` |
 | Get reference projects | `mcp__workspace__get_reference_projects` |
+| Search reference files | `mcp__workspace__search_reference_files` |
+| Get base branch | `mcp__workspace__get_base_branch` |
+| Check file size | `mcp__workspace__check_file_size` (default max_lines=600) |
+| Check branch status | `mcp__workspace__check_branch_status` |
 | Run pytest | `mcp__tools-py__run_pytest_check` |
 | Run pylint | `mcp__tools-py__run_pylint_check` |
 | Run mypy | `mcp__tools-py__run_mypy_check` |
@@ -32,17 +36,11 @@ Use MCP tools for **all** operations. Never use `Read`, `Write`, `Edit`, or `Bas
 | Format code (black+isort) | `mcp__tools-py__run_format_code` |
 | Get library source | `mcp__tools-py__get_library_source` |
 | Refactoring | `mcp__tools-py__move_symbol`, `move_module`, `rename_symbol`, `list_symbols`, `find_references` |
-| Git status | `mcp__workspace__git_status` |
-| Git diff (includes compact diff) | `mcp__workspace__git_diff` |
-| Git log | `mcp__workspace__git_log` |
-| Git merge-base | `mcp__workspace__git_merge_base` |
 | Git read-only (fetch, ls-tree, show, ls-files, ls-remote, rev-parse, branch list) | `mcp__workspace__git` |
 | `gh issue view` | `mcp__workspace__github_issue_view` |
 | `gh issue list` | `mcp__workspace__github_issue_list` |
 | `gh pr view` | `mcp__workspace__github_pr_view` |
 | `gh search` | `mcp__workspace__github_search` |
-| Check branch status | `mcp__workspace__check_branch_status` |
-| Check file size | `mcp__workspace__check_file_size` (default max_lines=600) |
 
 ## Code quality checks
 
@@ -73,7 +71,7 @@ mcp-coder gh-tool set-status <label>
 
 **Status labels:** use `mcp-coder gh-tool set-status` to change issue workflow status — never use raw `gh issue edit` with label flags.
 
-**Compact diff:** use `mcp__workspace__git_diff` for code review. Has compact diff built-in with exclude pattern support.
+**Compact diff:** use `mcp__workspace__git` for code review. Has compact diff built-in with exclude pattern support.
 
 **Before every commit:** run `mcp__tools-py__run_format_code`, then stage and commit.
 

--- a/.claude/knowledge_base/refactoring_principles.md
+++ b/.claude/knowledge_base/refactoring_principles.md
@@ -15,8 +15,8 @@ Quick reference for refactoring rules and tools. For detailed process, examples,
 1. Plan target structure
 2. Move source code — `move_symbol` / `move_module`
 3. Move tests to mirror new structure
-4. Review diff — `mcp__workspace__git_diff` (remaining diff should be imports only)
+4. Review diff — `mcp__workspace__git` with command `"diff"` (remaining diff should be imports only)
 5. Run all checks — pytest, pylint, mypy, ruff
-6. Check file sizes — `mcp-coder check file-size --max-lines 750`
+6. Check file sizes — `mcp__workspace__check_file_size` with `max_lines=750`
 
 See [Safe Refactoring Guide](../../docs/processes-prompts/refactoring-guide.md) for the full checklist.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,6 @@
 {
   "permissions": {
     "allow": [
-      "Bash(mcp-coder check branch-status:*)",
-      "Bash(mcp-coder check file-size:*)",
       "Bash(mcp-coder gh-tool:*)",
       "mcp__tools-py__find_references",
       "mcp__tools-py__get_library_source",
@@ -24,10 +22,6 @@
       "mcp__workspace__edit_file",
       "mcp__workspace__get_reference_projects",
       "mcp__workspace__git",
-      "mcp__workspace__git_diff",
-      "mcp__workspace__git_log",
-      "mcp__workspace__git_merge_base",
-      "mcp__workspace__git_status",
       "mcp__workspace__github_issue_list",
       "mcp__workspace__github_issue_view",
       "mcp__workspace__github_pr_view",
@@ -71,6 +65,8 @@
       "mcp__obsidian-wiki__rename-tag",
       "mcp__obsidian-wiki__search-vault",
       "mcp__workspace__check_branch_status",
+      "mcp__workspace__check_file_size",
+      "mcp__workspace__get_base_branch",
       "Bash(git commit:*)",
       "Bash(git push:*)"
     ]

--- a/.claude/skills/check_branch_status/SKILL.md
+++ b/.claude/skills/check_branch_status/SKILL.md
@@ -2,10 +2,10 @@
 description: Check branch readiness including CI, rebase needs, tasks, and labels
 disable-model-invocation: true
 allowed-tools:
-  - "Bash(mcp-coder check branch-status *)"
+  - mcp__workspace__check_branch_status
 ---
 
-!`mcp-coder check branch-status --ci-timeout 180 --llm-truncate`
+!`Call mcp__workspace__check_branch_status`
 
 # Check Branch Status
 

--- a/.claude/skills/commit_push/SKILL.md
+++ b/.claude/skills/commit_push/SKILL.md
@@ -2,9 +2,7 @@
 description: Format code, review changes, commit, and push to remote
 disable-model-invocation: true
 allowed-tools:
-  - mcp__workspace__git_status
-  - mcp__workspace__git_diff
-  - mcp__workspace__git_log
+  - mcp__workspace__git
   - "Bash(git add *)"
   - "Bash(git commit *)"
   - "Bash(git push *)"
@@ -22,8 +20,8 @@ Follow this process to commit and push your changes:
 Use `mcp__tools-py__run_format_code` to format all code (black + isort).
 
 ## 2. Review Changes
-Use `mcp__workspace__git_status` to check working directory state.
-Use `mcp__workspace__git_diff` to review the changes.
+Use `mcp__workspace__git` with command `"status"` to check working directory state.
+Use `mcp__workspace__git` with command `"diff"` to review the changes.
 
 ## 3. Stage Changes
 Stage all relevant changes (exclude any files that shouldn't be committed).

--- a/.claude/skills/implementation_approve/SKILL.md
+++ b/.claude/skills/implementation_approve/SKILL.md
@@ -3,7 +3,7 @@ description: Approve implementation and transition issue to PR-ready state
 disable-model-invocation: true
 allowed-tools:
   - "Bash(mcp-coder gh-tool set-status *)"
-  - "Bash(mcp-coder check branch-status *)"
+  - mcp__workspace__check_branch_status
 ---
 
 # Approve Implementation
@@ -12,13 +12,11 @@ Approve the implementation and transition the issue to PR-ready state.
 
 **Instructions:**
 1. Run branch-status check:
-```bash
-mcp-coder check branch-status --ci-timeout 600 --pr-timeout 600 --llm-truncate
-```
+Call `mcp__workspace__check_branch_status`.
 
 2. If `branch-status` reports a base branch other than `main`, ask the user to confirm this is intentional before proceeding.
 
-3. Only if the branch-status check passes (exit code 0), run the set-status command and confirm it succeeded:
+3. Only if the branch-status check passes, run the set-status command and confirm it succeeded:
 ```bash
 mcp-coder gh-tool set-status status-08:ready-pr
 ```
@@ -27,7 +25,4 @@ mcp-coder gh-tool set-status status-08:ready-pr
 
 **Effect:** Changes issue status from `status-07:code-review` to `status-08:ready-pr`.
 
-4. After the label is set, poll for the PR to be created and pass CI. This runs in the background — the background process creates the PR while it polls (up to 600s):
-```bash
-mcp-coder check branch-status --ci-timeout 600 --pr-timeout 600 --llm-truncate --wait-for-pr
-```
+4. After the label is set, call `mcp__workspace__check_branch_status` again to verify CI and PR status.

--- a/.claude/skills/implementation_review/SKILL.md
+++ b/.claude/skills/implementation_review/SKILL.md
@@ -3,9 +3,7 @@ description: Code review of implementation with compact diff analysis
 disable-model-invocation: true
 allowed-tools:
   - mcp__workspace__git
-  - mcp__workspace__git_status
-  - mcp__workspace__git_diff
-  - "Bash(mcp-coder check branch-status *)"
+  - mcp__workspace__check_branch_status
   - mcp__workspace__read_file
   - mcp__workspace__list_directory
   - Glob
@@ -16,10 +14,8 @@ allowed-tools:
 
 **First, ensure we're up to date:**
 Call `mcp__workspace__git` with command `"fetch"` and args `["origin"]`.
-Use `mcp__workspace__git_status` to check working directory state.
-```bash
-mcp-coder check branch-status --llm-truncate
-```
+Use `mcp__workspace__git` with command `"status"` to check working directory state.
+Call `mcp__workspace__check_branch_status`.
 
 Confirm and display the current feature branch name.
 
@@ -29,7 +25,7 @@ Confirm and display the current feature branch name.
 
 ## Code Review Request
 
-Use `mcp__workspace__git_diff` to get the changes to review.
+Use `mcp__workspace__git` with command `"diff"` to get the changes to review.
 
 No need to run all checks; do not use pylint warnings. Feel free to further analyse any mentioned files and/or the file structure.
 

--- a/.claude/skills/implementation_review_supervisor/SKILL.md
+++ b/.claude/skills/implementation_review_supervisor/SKILL.md
@@ -3,9 +3,8 @@ description: Autonomous code review — supervisor delegates to engineer subagen
 disable-model-invocation: true
 allowed-tools:
   - mcp__workspace__github_issue_view
-  - "Bash(mcp-coder check branch-status *)"
-  - mcp__workspace__git_status
-  - mcp__workspace__git_diff
+  - mcp__workspace__check_branch_status
+  - mcp__workspace__git
   - mcp__workspace__read_file
   - mcp__workspace__save_file
   - mcp__workspace__edit_file
@@ -74,6 +73,6 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 **Status**: {committed / no changes needed}
 ```
 
-**Subagent instructions:** Remind subagents to follow CLAUDE.md (MCP tools, no `cd` prefix, approved commands only).
+**Subagent instructions:** When launching subagents, instruct them to follow CLAUDE.md — especially the MCP tool requirements (use `mcp__workspace__*` tools, not native file tools). Also remind them: no `cd` prefix, approved commands only.
 
 **Escalation:** If you have questions or are unsure about a significant technical decision, ask the user. For borderline Accept/Skip findings, default to better code quality rather than asking — only escalate when the fix has meaningful scope or risk, not for trivial changes in either direction. Import contract or architecture violations (from `run_lint_imports_check`): escalate to the user — fixes may require moving code between layers.

--- a/.claude/skills/issue_analyse/SKILL.md
+++ b/.claude/skills/issue_analyse/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools:
   - mcp__workspace__git
   - mcp__workspace__read_file
   - mcp__workspace__list_directory
+  - mcp__tools-py__sleep
 ---
 
 # Analyse GitHub Issue
@@ -19,6 +20,8 @@ The user may provide an issue number as the argument (available as `$ARGUMENTS`)
 If no issue number is provided:
 1. Read `.vscodeclaude_status.txt` and extract the issue number from the `Issue #NNN` line
 2. If the file doesn't exist or has no issue number, ask the user
+
+Wait one second using `mcp__tools-py__sleep` with `sleep_seconds: 1`.
 
 Fetch the issue:
 Call `mcp__workspace__github_issue_view` with the issue number.

--- a/.claude/skills/plan_review/SKILL.md
+++ b/.claude/skills/plan_review/SKILL.md
@@ -3,7 +3,6 @@ description: Review implementation plan for completeness, simplicity, and risks
 disable-model-invocation: true
 allowed-tools:
   - mcp__workspace__git
-  - mcp__workspace__git_status
   - mcp__workspace__read_file
   - mcp__workspace__list_directory
   - Glob
@@ -14,7 +13,7 @@ allowed-tools:
 
 **First, ensure we're up to date:**
 Call `mcp__workspace__git` with command `"fetch"` and args `["origin"]`.
-Use `mcp__workspace__git_status` to check working directory state.
+Use `mcp__workspace__git` with command `"status"` to check working directory state.
 
 Confirm and display the current feature branch name.
 

--- a/.claude/skills/plan_review_supervisor/SKILL.md
+++ b/.claude/skills/plan_review_supervisor/SKILL.md
@@ -65,7 +65,7 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 **Status**: {committed / no changes needed}
 ```
 
-**Subagent instructions:** Remind subagents to follow CLAUDE.md (MCP tools, no `cd` prefix, approved commands only).
+**Subagent instructions:** When launching subagents, instruct them to follow CLAUDE.md — especially the MCP tool requirements (use `mcp__workspace__*` tools, not native file tools). Also remind them: no `cd` prefix, approved commands only.
 
 **Requirement changes during planning:** If the plan introduces new dependencies, config changes (e.g., `pyproject.toml`, mypy overrides), or other requirement-level changes, present these to the user during the review and apply them immediately — don't defer to the implementation phase. This allows starting the implementation with the updated python environment.
 

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -2,8 +2,6 @@
 description: Rebase feature branch onto base branch with conflict resolution
 disable-model-invocation: true
 allowed-tools:
-  - mcp__workspace__git_status
-  - mcp__workspace__git_log
   - mcp__workspace__git
   - "Bash(git rebase *)"
   - "Bash(git add *)"
@@ -15,9 +13,8 @@ allowed-tools:
   - "Bash(git restore *)"
   - "Bash(git stash *)"
   - "Bash(git push --force-with-lease *)"
-  - mcp__workspace__git_diff
   - mcp__tools-py__run_format_code
-  - "Bash(mcp-coder gh-tool get-base-branch *)"
+  - mcp__workspace__get_base_branch
   - mcp__tools-py__run_pylint_check
   - mcp__tools-py__run_pytest_check
   - mcp__tools-py__run_mypy_check
@@ -37,7 +34,7 @@ allowed-tools:
 
 ## First Step
 
-Call `mcp__workspace__git_status` before doing anything else.
+Call `mcp__workspace__git` with command `"status"` before doing anything else.
 
 Rebase the current feature branch onto its base branch and resolve conflicts.
 
@@ -49,11 +46,7 @@ If the rebase becomes complex, suggest switching to cherry-picking as an alterna
 
 ## Determine Base Branch
 
-First, detect the correct base branch:
-```bash
-BASE_BRANCH=$(mcp-coder gh-tool get-base-branch)
-echo "Rebasing onto: $BASE_BRANCH"
-```
+Call `mcp__workspace__get_base_branch` to detect the correct base branch. Use the returned branch name in subsequent git commands.
 
 ## Base Branch Confirmation
 

--- a/.claude/skills/rebase/rebase_design.md
+++ b/.claude/skills/rebase/rebase_design.md
@@ -15,10 +15,8 @@ The slash command requires two sets of permissions in `allowed-tools`:
 These are the additional git permissions needed specifically for rebase operations:
 
 ```
-# Status and investigation (MCP tools for read-only operations)
-mcp__workspace__git_status
-mcp__workspace__git_log
-mcp__workspace__git  # read-only: fetch, branch, ls-files, rev-parse
+# Status, log, diff, and investigation (MCP tool for read-only operations)
+mcp__workspace__git  # read-only: status, log, diff, merge_base, fetch, branch, ls-files, rev-parse
 
 # Rebasing
 Bash(git rebase:*)


### PR DESCRIPTION
## Summary
- Replace removed `git_status`/`git_diff`/`git_log`/`git_merge_base` tools with consolidated `mcp__workspace__git` across CLAUDE.md, settings, and all skills
- Add `search_reference_files`, `get_base_branch`, `check_file_size` to tool mapping and permissions
- Replace `Bash(mcp-coder check branch-status/file-size)` with MCP equivalents in skills
- Add `mcp__tools-py__sleep` to `issue_analyse` skill
- Replace `get-base-branch` CLI with `mcp__workspace__get_base_branch` in rebase skill
- Strengthen subagent MCP tool instructions in supervisor skills

## Test plan
- [ ] Verify skills load correctly (no YAML frontmatter errors)
- [ ] Verify `/check_branch_status` works with new MCP tool
- [ ] Verify `/rebase` detects base branch via MCP tool

Part of #13