### PR TITLE
chore(mcp): wire obsidian-dev-wiki as MCP server and reference project

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -44,11 +44,25 @@
         "--reference-project",
         "name=mcp-coder-utils,path=${USERPROFILE}\\Documents\\GitHub\\mcp-coder-utils,url=https://github.com/MarcusJellinghaus/mcp-coder-utils",
         "--reference-project",
-        "name=mcp-tools-py,path=${USERPROFILE}\\Documents\\GitHub\\mcp-tools-py,url=https://github.com/MarcusJellinghaus/mcp-tools-py"
+        "name=mcp-tools-py,path=${USERPROFILE}\\Documents\\GitHub\\mcp-tools-py,url=https://github.com/MarcusJellinghaus/mcp-tools-py",
+        "--reference-project",
+        "name=obsidian-dev-wiki,path=${USERPROFILE}\\Documents\\GitHub\\obsidian-dev-wiki,url=https://github.com/MarcusJellinghaus/obsidian-dev-wiki"
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_VENV_DIR}\\Lib\\"
       }
+    },
+    "obsidian-wiki": {
+      "type": "stdio",
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "obsidian-mcp",
+        "${USERPROFILE}\\Documents\\GitHub\\obsidian-dev-wiki"
+      ],
+      "env": {}
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `obsidian-wiki` MCP server entry (via `npx obsidian-mcp`) pointed at the local `obsidian-dev-wiki` vault.
- Register `obsidian-dev-wiki` as a reference project on the `mcp-workspace` server so Claude can read it like other sibling repos.

## Why
Cross-repo process notes (Chore Implementation, Chore Propagation, Cross-Repo Chores) live in the vault. Wiring it into `.mcp.json` lets Claude follow those processes from within this repo without having to be told where the vault is.

## Test plan
- [ ] `.mcp.json` parses as valid JSON.
- [ ] After restarting the MCP client, `obsidian-wiki` tools (`search-vault`, `read-note`, etc.) appear.
- [ ] `mcp-workspace` lists `obsidian-dev-wiki` under reference projects.