### PR TITLE
chore: file-size limit config, gitignore and CLAUDE.md updates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -87,6 +87,10 @@ mcp-coder gh-tool set-status <label>
 
 Be concise. If one line works, don't use three.
 
+## Asking questions
+
+Never use the AskUserQuestion tool. Ask questions as plain text in the chat.
+
 ## Obsidian knowledge base
 
 An Obsidian vault (`obsidian-dev-wiki`) is available via the `obsidian-wiki` MCP server.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,7 +23,7 @@ Use MCP tools for **all** operations. Never use `Read`, `Write`, `Edit`, or `Bas
 | Get reference projects | `mcp__mcp-workspace__get_reference_projects` |
 | Search reference files | `mcp__mcp-workspace__search_reference_files` |
 | Get base branch | `mcp__mcp-workspace__get_base_branch` |
-| Check file size | `mcp__mcp-workspace__check_file_size` (default max_lines=600) |
+| Check file size | `mcp__mcp-workspace__check_file_size` (default max_lines=750) |
 | Check branch status | `mcp__mcp-workspace__check_branch_status` |
 | Run pytest | `mcp__mcp-tools-py__run_pytest_check` |
 | Run pylint | `mcp__mcp-tools-py__run_pylint_check` |

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ uv.lock
 .vscodeclaude_analysis.json
 .vscodeclaude_start.bat
 .vscodeclaude_start.sh
+.vscodeclaude_session.json
 
 # Windows reserved-name artifacts
 nul

--- a/.mcp.json
+++ b/.mcp.json
@@ -28,6 +28,8 @@
         "${MCP_CODER_PROJECT_DIR}",
         "--log-level",
         "INFO",
+        "--file-size-limit",
+        "750",
         "--reference-project",
         "name=mcp_coder,path=${USERPROFILE}\\Documents\\GitHub\\mcp_coder,url=https://github.com/MarcusJellinghaus/mcp_coder",
         "--reference-project",

--- a/.mcp.linux.json
+++ b/.mcp.linux.json
@@ -28,6 +28,8 @@
         "${MCP_CODER_PROJECT_DIR}",
         "--log-level",
         "INFO",
+        "--file-size-limit",
+        "750",
         "--reference-project",
         "name=mcp_coder,path=${HOME}/Documents/GitHub/mcp_coder,url=https://github.com/MarcusJellinghaus/mcp_coder",
         "--reference-project",

--- a/.mcp.macos.json
+++ b/.mcp.macos.json
@@ -28,6 +28,8 @@
         "${MCP_CODER_PROJECT_DIR}",
         "--log-level",
         "INFO",
+        "--file-size-limit",
+        "750",
         "--reference-project",
         "name=mcp_coder,path=${HOME}/Documents/GitHub/mcp_coder,url=https://github.com/MarcusJellinghaus/mcp_coder",
         "--reference-project",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp>=1.3.0",
-    "mcp[cli]>=1.3.0",
+    # <2.0.0: mcp 2.x drops mcp.server.fastmcp (FastMCP -> MCPServer). See #46.
+    "mcp>=1.3.0,<2.0.0",
+    "mcp[cli]>=1.3.0,<2.0.0",
     "structlog>=24.5.0",
     "python-json-logger>=3.2.1",
     "mcp-coder-utils",


### PR DESCRIPTION
Works through three sections of the chore list, plus an unrelated CI fix that
had to land here to get the branch green (see below).

## `--file-size-limit 750`

`mcp-workspace` gained `--file-size-limit`, which sets the default used by
`check_file_size` when `max_lines` is omitted. Without it the tool defaults to
600 and reports `tests/test_update_tools.py` (718) and
`tests/test_validation_tools.py` (654) as violations, though both pass CI at 750.

Applied to all three platform configs so macOS and Linux sessions do not
silently keep the 600 default. Only `.mcp.json` is verifiable here (Windows);
the other two are applied blind. The tool-mapping table in `.claude/CLAUDE.md`
is updated to match.

Verified by calling `check_file_size` with an explicit `max_lines: 750`:
all 141 files pass.

## `.vscodeclaude_session.json` in `.gitignore`

The vscodeclaude launcher appends this entry on every session launch but never
commits it, so every session starts with a modified `.gitignore`. Committing it
once makes the launch-time update a no-op. Moved from the credential block
where the launcher appends it into the `.vscodeclaude_*` block.

## Forbid the AskUserQuestion tool

Its UI truncates question context, making options hard to evaluate. Questions
go in the chat as plain text instead.

## Cap `mcp` below 2.0.0

Not a chore item. CI on this branch was failing all six jobs before any of the
above landed: `mcp` 2.0.0 implements the 2026-07-28 spec revision and removes
`mcp.server.fastmcp` (`FastMCP` renamed `MCPServer`, moved to `mcp.server`).
The dependency was unbounded, so a fresh resolve picked 2.0.0 and every job
died at import.

Capped at `<2.0.0`, pinning resolution to 1.29.x. Stopgap only — the migration
is tracked in #46, mirroring MarcusJellinghaus/mcp-workspace#243.

Verified in the project venv after the downgrade: 522 passed, 16 skipped;
pylint and mypy both clean (they had been reporting 40 mypy errors and ~30
pylint import errors, all from the missing module).

## Not included

The `black` floor item was dropped: `pyproject.toml` has no `black` entry since
PR #42 made `mcp-tools-py` the single source for the toolchain, so the floor is
inherited rather than pinned here.

Part of #13
Part of #46