### PR TITLE
chore(skills): unblock supervisor-delegated skills

### DIFF
--- a/.claude/skills/check_branch_status/SKILL.md
+++ b/.claude/skills/check_branch_status/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Check branch readiness including CI, rebase needs, tasks, and labels
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__check_branch_status
 ---

--- a/.claude/skills/implementation_review/SKILL.md
+++ b/.claude/skills/implementation_review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Code review of implementation with compact diff analysis
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__git
   - mcp__mcp-workspace__check_branch_status

--- a/.claude/skills/plan_review/SKILL.md
+++ b/.claude/skills/plan_review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Review implementation plan for completeness, simplicity, and risks
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__git
   - mcp__mcp-workspace__read_file

--- a/.claude/skills/plan_update/SKILL.md
+++ b/.claude/skills/plan_update/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Update implementation plan files based on discussion
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__read_file
   - mcp__mcp-workspace__save_file


### PR DESCRIPTION
## Problem

`disable-model-invocation: true` restricts a skill to being started by the user typing `/name` — the model cannot invoke it through the Skill tool. It was set on all 20 skills.

Both review supervisors are built entirely on delegation and call other skills by name:

- `implementation_review_supervisor` — step 1 → `/implementation_review`, steps 6 and 10 → `/check_branch_status`
- `plan_review_supervisor` — step 1 → `/plan_review`, steps 2 and 3 → `/plan_update`

The subagent doing that work is a model, so every one of those calls was blocked. The supervisors' documented workflow could not run.

## Change

Removed `disable-model-invocation: true` from the four skills the supervisors call. That line only — descriptions and `allowed-tools` are untouched, and no skill body changed.

All 16 remaining skills keep the flag. Every one is user-typed: approvals, `commit_push`, `rebase`, `issue_*`, `implement_direct`, and the two supervisors themselves.
