### PR TITLE
chore: CLAUDE.md writing/Bash rules and .scratch/ convention

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,13 @@
 
 Use MCP tools for **all** operations. Never use `Read`, `Write`, `Edit`, or `Bash` for tasks that have an MCP equivalent. If no MCP equivalent exists, use Bash. Check the tool mapping table below first.
 
+**Justify Bash.** Before a Bash command or script, say in chat, on two lines:
+
+- *What it does* — one sentence.
+- *Why MCP doesn't* — which tool you'd have used, and what stops it.
+
+If you can't name the gap, use the MCP tool. Exempt: the approved git/gh commands under Git operations.
+
 ### Tool mapping
 
 | Task | MCP tool |
@@ -95,6 +102,8 @@ Be concise. Shorter is better — chat, commits, PRs, docs, comments alike.
 Say it once. Never restate what the reader can already see: the diff, the code, the issue, or my own earlier message. Cut it; don't rephrase it.
 
 If a sentence isn't load-bearing, delete it.
+
+Readable beats short. Cut what I don't need; don't compress what stays — complete sentences, no arrow chains or invented abbreviations. Lead with the outcome.
 
 ## Asking questions
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,6 +13,8 @@ Use MCP tools for **all** operations. Never use `Read`, `Write`, `Edit`, or `Bas
 
 If you can't name the gap, use the MCP tool. Exempt: the approved git/gh commands under Git operations.
 
+**No session scratchpad.** MCP tools can't write outside the project. Temporary files go in `.scratch/`.
+
 ### Tool mapping
 
 | Task | MCP tool |
@@ -41,6 +43,7 @@ If you can't name the gap, use the MCP tool. Exempt: the approved git/gh command
 | Run ruff fix | `mcp__mcp-tools-py__run_ruff_fix` |
 | Run bandit | `mcp__mcp-tools-py__run_bandit_check` |
 | Format code (black+isort) | `mcp__mcp-tools-py__run_format_code` |
+| Check a Python semantic before claiming it | scratch probe — see [Scratch probes](#scratch-probes) |
 | Get library source | `mcp__mcp-tools-py__get_library_source` |
 | Refactoring | `mcp__mcp-tools-py__move_symbol`, `move_module`, `rename_symbol`, `list_symbols`, `find_references` |
 | Git read-only (fetch, ls-tree, show, ls-files, ls-remote, rev-parse, branch list) | `mcp__mcp-workspace__git` |
@@ -68,6 +71,19 @@ All checks must pass before proceeding.
 **Pytest:** always use `extra_args: ["-n", "auto"]` for parallel execution.
 
 When debugging test failures, add `"-v", "-s", "--tb=short"` to extra_args.
+
+## Scratch probes
+
+Don't assert Python behaviour you haven't run. Probe it:
+
+```python
+mcp__mcp-workspace__save_file(".scratch/test_probe.py", ...)
+mcp__mcp-tools-py__run_pytest_check(extra_args=["-p", "no:cacheprovider", ".scratch/test_probe.py"])
+```
+
+A path argument scopes the run, so a probe costs seconds. Delete when done — `delete_directory(".scratch", recursive=True)`; CI blocks any PR carrying one. `.scratch/` is not gitignored: the MCP file tools refuse ignored paths.
+
+Never use `python -c` via Bash. If you reason instead of running, label the conclusion analytical.
 
 ## Git operations
 

--- a/.claude/skills/discuss/SKILL.md
+++ b/.claude/skills/discuss/SKILL.md
@@ -15,6 +15,6 @@ Please offer, whenever possible, simple options like
 - C
 Always just ask ONE question
 
-Keep each round concise and readable — complete sentences, no arrow chains or invented abbreviations. Lead with the outcome.
+Keep each round concise and readable.
 
 Mark the option you prefer and say in one sentence why.

--- a/.claude/skills/discuss/SKILL.md
+++ b/.claude/skills/discuss/SKILL.md
@@ -14,3 +14,7 @@ Please offer, whenever possible, simple options like
 - B
 - C
 Always just ask ONE question
+
+Keep each round concise and readable — complete sentences, no arrow chains or invented abbreviations. Lead with the outcome.
+
+Mark the option you prefer and say in one sentence why.

--- a/.claude/skills/issue_update/SKILL.md
+++ b/.claude/skills/issue_update/SKILL.md
@@ -28,17 +28,17 @@ Based on our prior `/issue_analyse` discussion, update the GitHub issue with ref
 
 4. Write the issue body to a temp file (avoids bash escaping issues with markdown):
 ```python
-mcp__mcp-workspace__save_file(file_path="issue_body_temp.md", content=body_content)
+mcp__mcp-workspace__save_file(file_path=".scratch/issue_body_temp.md", content=body_content)
 ```
 
 5. Update the issue using `--body-file`:
 ```bash
-gh issue edit <issue_number> --title "NEW_TITLE" --body-file issue_body_temp.md
+gh issue edit <issue_number> --title "NEW_TITLE" --body-file .scratch/issue_body_temp.md
 ```
 
 6. Clean up the temp file:
 ```python
-mcp__mcp-workspace__delete_this_file(file_path="issue_body_temp.md")
+mcp__mcp-workspace__delete_this_file(file_path=".scratch/issue_body_temp.md")
 ```
 
 **Editing Base Branch:**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         ERROR=0
 
         check_forbidden_folder "pr_info" "Temporary development folder (planning, tracking, review logs)" || ERROR=1
+        check_forbidden_folder ".scratch" "Agent scratch probes (throwaway tests) - delete after the experiment" || ERROR=1
 
         if [ $ERROR -eq 1 ]; then
           echo ""


### PR DESCRIPTION
Two chore sections from #13, plus a `/discuss` tweak.

**Writing style: readability rule, and justify Bash usage**
- `.claude/CLAUDE.md` — readability line in `## Writing style`; `Justify Bash` under `## MCP Tools — mandatory`

**Adopt `.scratch/` for agent probes and temp files**
- `.claude/CLAUDE.md` — `No session scratchpad`, `## Scratch probes`, tool-mapping row
- `.github/workflows/ci.yml` — `.scratch` added to `check-forbidden-folders`
- `.claude/skills/issue_update/SKILL.md` — temp file moved to `.scratch/issue_body_temp.md`
- `.gitignore` untouched by design: the MCP file tools refuse ignored paths

Verified by hand that the MCP file tools can create, run and delete a probe inside `.scratch/`. The CI guard itself was not exercised — the added line duplicates the existing `pr_info` call in the same function.

**`/discuss`** — answers stay concise and readable, and mark the preferred option.

Part of #13
